### PR TITLE
proprietary features need to be removed

### DIFF
--- a/doc/release-notes/contrail-release-notes-5.0.1-title.rst
+++ b/doc/release-notes/contrail-release-notes-5.0.1-title.rst
@@ -23,50 +23,15 @@ Table of Contents
 
      -  `New and Changed Features in Contrail Release 5.0.1`_ 
 
-       -  `Bare Metal Server Life Cycle Management`_ 
-
-
-       -  `Contrail Support for Underlay Management`_ 
-
-
        -  `Support for Advertising of Local AS to BGP Peers`_ 
-
-
-       -  `Support for Contrail Command UI`_ 
-
-         -  `Usage of Contrail Command UI`_ 
-
-
-
-       -  `Support for Configuring QFX10000 as a DataCenter Gateway`_ 
-
-
-       -  `Support for Red Hat OpenShift Container Platform Version 3.9`_ 
-
-
-       -  `Support for Contrail Cloud Release 13.0`_ 
-
-
-       -  `Support for AppFormix Features`_ 
-
 
        -  `Support for EVPN Route Type 5`_ 
 
-
        -  `Support For Encryption of Traffic Between vRouters`_ 
-
-
-       -  `Contrail Plugin For VMware vRealize Orchestrator`_ 
-
 
        -  `Support for Mellanox Connectx-5 NIC`_ 
 
-
        -  `Support for Remote Compute`_ 
-
-
-       -  `Support for Red Hat OpenStack Platform Director 13`_ 
-
 
        -  `Documentation Update`_ 
 
@@ -125,20 +90,10 @@ Table of Contents
        -  `Using Helm Charts to Provision Contrail`_ 
 
 
-       -  `Contrail Plugin For VMware vRealize Orchestrator—Beta`_ 
-
-
        -  `RBAC Support for Contrail Analytics API—Beta`_ 
 
 
        -  `Remote Compute—Beta`_ 
-
-
-       -  `Contrail Cloud`_ 
-
-
-       -  `OpenShift Enterprise`_ 
-
 
 
 
@@ -178,35 +133,15 @@ Table of Contents
 
 .. _New and Changed Features in Contrail Release 5.0.1:  new-and-changed-features.html
 
-.. _Bare Metal Server Life Cycle Management:  new-and-changed-features.html
-
-.. _Contrail Support for Underlay Management:  new-and-changed-features.html
-
 .. _Support for Advertising of Local AS to BGP Peers:  new-and-changed-features.html
-
-.. _Support for Contrail Command UI:  new-and-changed-features.html
-
-.. _Usage of Contrail Command UI:  new-and-changed-features.html
-
-.. _Support for Configuring QFX10000 as a DataCenter Gateway:  new-and-changed-features.html
-
-.. _Support for Red Hat OpenShift Container Platform Version 3.9:  new-and-changed-features.html
-
-.. _Support for Contrail Cloud Release 13.0:  new-and-changed-features.html
-
-.. _Support for AppFormix Features:  new-and-changed-features.html
 
 .. _Support for EVPN Route Type 5:  new-and-changed-features.html
 
 .. _Support For Encryption of Traffic Between vRouters:  new-and-changed-features.html
 
-.. _Contrail Plugin For VMware vRealize Orchestrator:  new-and-changed-features.html
-
 .. _Support for Mellanox Connectx-5 NIC:  new-and-changed-features.html
 
 .. _Support for Remote Compute:  new-and-changed-features.html
-
-.. _Support for Red Hat OpenStack Platform Director 13:  new-and-changed-features.html
 
 .. _Documentation Update:  new-and-changed-features.html
 
@@ -246,15 +181,9 @@ Table of Contents
 
 .. _Using Helm Charts to Provision Contrail:  new-and-changed-features.html
 
-.. _Contrail Plugin For VMware vRealize Orchestrator—Beta:  new-and-changed-features.html
-
 .. _RBAC Support for Contrail Analytics API—Beta:  new-and-changed-features.html
 
 .. _Remote Compute—Beta:  new-and-changed-features.html
-
-.. _Contrail Cloud:  new-and-changed-features.html
-
-.. _OpenShift Enterprise:  new-and-changed-features.html
 
 .. _Supported Platforms Contrail 5.0:  supported-platforms-50-vnc.html
 


### PR DESCRIPTION
Original release notes contains several proprietary features, which is not open sourced.
As the first step of Contrail -> Tungsten Fabric, I'll remove the part of this document which is not included in Tungsten Fabric repo.